### PR TITLE
DbRepository now implements RepositoryInterface

### DIFF
--- a/app/lib/Repositories/DbRepository.php
+++ b/app/lib/Repositories/DbRepository.php
@@ -3,7 +3,7 @@
 use Contracts\Repositories\OrderRepositoryInterface;
 use Contracts\Instances\InstanceInterface;
 
-abstract class DbRepository implements OrderRepositoryInterface
+abstract class DbRepository implements RepositoryInterface
 {
 
     protected $model;


### PR DESCRIPTION
I believe implementing `OrderRepositoryInterface` was a mistake
